### PR TITLE
changed the base image to ubuntu to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # First stage
-FROM python:3.8
+FROM ubuntu:20.04
 
 RUN apt-get update -y && \
     apt-get install -y python3-pip python3-dev
@@ -11,7 +11,7 @@ WORKDIR  /app
 #RUN echo "export PATH=/root/.local:$PATH" >> ~/.bashrc
 
 # Install dependecies
-RUN pip install -r requirements.txt
+RUN pip3 install -r requirements.txt
 
 COPY . /app
 


### PR DESCRIPTION
Hey
I have worked on #17 on making the image size smaller. To achieve this I have changed the base image to ubuntu keeping in mind the long term support for Ubuntu:20.04 and build time. We could have used alpine based image for much smaller image but that might cause instability and longer build times (it's best to avoid alpine based images).

The current change brings down the image size to 426MB which is quite an improvement from the previous image. I will still try to work on multistage builds in docker in the future and try if that can make any difference.

![image](https://user-images.githubusercontent.com/6022231/103461405-5a1e9280-4d44-11eb-8fb4-5b94f159a561.png)


You can try my changes at [Try Now](https://gitpod.io/#https://github.com/anudeepreddy/bertelsmannlearners)

Click on the link above then login with github. After the workspace is ready run `sudo docker-up` and build the docker image using `sudo docker build .`.

Hope this helps
Cheers✌